### PR TITLE
Filter ranking by genre or tag with other SteamSpy API calls

### DIFF
--- a/download_json.py
+++ b/download_json.py
@@ -4,7 +4,7 @@ from urllib.request import urlopen
 import json
 import pathlib
 
-def downloadSteamSpyData(json_filename = "steamspy.json"):
+def downloadSteamSpyData(json_filename = "steamspy.json", genre = None, tag = None):
 
     # Data folder
     data_path = "data/"
@@ -15,6 +15,17 @@ def downloadSteamSpyData(json_filename = "steamspy.json"):
 
     # If json_filename is missing, we will attempt to download and cache it from steamspy_url:
     steamspy_url = "http://steamspy.com/api.php?request=all"
+
+    # Provide a possibility to download data for a given genre
+    if bool(not(genre is None)):
+        print("Focusing on genre " + genre)
+        formatted_str = genre.replace(" ", "+")
+        steamspy_url = "http://steamspy.com/api.php?request=genre&genre=" + formatted_str
+    # Provide a possibility to download data for a given tag
+    elif bool(not(tag is None)):
+        print("Focusing on tag " + tag)
+        formatted_str = tag.replace(" ", "+")
+        steamspy_url = "http://steamspy.com/api.php?request=tag&tag=" + formatted_str
 
     try:
         with open(data_filename, 'r', encoding="utf8") as in_json_file:


### PR DESCRIPTION
This allows to filter-in appID based on genre or tag.
For instance, to focus on games whose genres or tags include "Software".

Please note that, given a keyword, this procedure requires two additional SteamSpy API requests (one for the genre, one for the tag), on top of the usual aggregated SteamSpy API request.